### PR TITLE
support evaluate alert payload

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,3 +3,42 @@ notify:
   pagerduty:
     # REF: https://support.pagerduty.com/docs/generating-api-keys
     key: <pagerduty_integrate_key>
+evaluate:
+  # evaluate alert payload include .evaluate.data
+  type: include
+  data:
+    receiver: dead-mans-switch
+    status: firing
+    alerts:
+      - status: firing
+        labels:
+          alertname: Watchdog
+          cluster: base
+          prometheus: monitoring/k8s
+          provider: eks
+          region: us-west-2
+          severity: none
+      - status: firing
+        labels:
+          alertname: Watchdog
+          cluster: seed
+          prometheus: monitoring/k8s
+          provider: eks
+          region: us-west-2
+          severity: none
+      - status: firing
+        labels:
+          alertname: Watchdog
+          cluster: seed
+          prometheus: monitoring/k8s
+          provider: gke
+          region: us-west1
+          severity: none
+      - status: firing
+        labels:
+          alertname: Watchdog
+          cluster: seed
+          prometheus: monitoring/k8s
+          provider: gke
+          region: us-west2
+          severity: none

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
+	"github.com/prometheus/alertmanager/template"
 )
 
 type Config struct {
@@ -21,8 +22,16 @@ type Pagerduty struct {
 	Key string
 }
 
+type EvaluateType string
+
+const(
+	EvaluateEqual EvaluateType = "equal"
+	EvaluateInclude EvaluateType = "include"
+)
+
 type Evaluate struct {
-	// TODO: add evaluate rules
+	Data template.Data
+	Type EvaluateType
 }
 
 func ParseConfig(path string) (*Config, error) {

--- a/dead_mans_switch_test.go
+++ b/dead_mans_switch_test.go
@@ -10,8 +10,8 @@ func TestDeadMansSwitchDoesntTrigger(t *testing.T) {
 	defer close(evaluateMessage)
 
 	notify := ""
-	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(msg string) error {
-		notify = msg
+	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(summary, detail string) error {
+		notify = summary
 		return nil
 	})
 
@@ -31,8 +31,9 @@ func TestDeadMansSwitchTrigger(t *testing.T) {
 	defer close(evaluateMessage)
 
 	notify := ""
-	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(msg string) error {
-		notify = msg
+	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(summary, detail string) error {
+		notify = summary
+
 		return nil
 	})
 
@@ -40,7 +41,7 @@ func TestDeadMansSwitchTrigger(t *testing.T) {
 	defer d.Stop()
 
 	time.Sleep(150 * time.Millisecond)
-	if notify != "DeadMansSwitchDown" {
+	if notify != "WatchdogDown" {
 		t.Fatal("deadman should trigger!")
 	}
 }
@@ -50,8 +51,10 @@ func TestEvaluateMessageNotNull(t *testing.T) {
 	defer close(evaluateMessage)
 
 	notify := ""
-	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(msg string) error {
-		notify = msg
+	notifyDetail := ""
+	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(summary, detail string) error {
+		notify = summary
+		notifyDetail = detail
 		return nil
 	})
 
@@ -60,7 +63,11 @@ func TestEvaluateMessageNotNull(t *testing.T) {
 
 	evaluateMessage <- "alert not as expected"
 
-	if notify != "alert not as expected" {
-		t.Fatal("notify msg should equal with evaluate message!")
+	if notify != "WatchdogAlertPayloadNotAsExpected" {
+		t.Fatal("summary should equal with WatchdogAlertPayloadNotAsExpected")
+	}
+
+	if notifyDetail != "alert not as expected" {
+		t.Fatal("notify detail should be equal with evaluate message")
 	}
 }

--- a/evaluate.go
+++ b/evaluate.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/prometheus/alertmanager/template"
+)
+
+func Include(i, j template.Data) (diff string) {
+	if i.Status != j.Status {
+		return fmt.Sprintf("status different, expected: %v, got: %v", i.Status, j.Status)
+	}
+
+	if i.Receiver != j.Receiver {
+		return fmt.Sprintf("receiver different, expected: %v, got: %v", i.Status, j.Status)
+	}
+
+	for index, k := range i.Alerts {
+		include := false
+		for _, l := range j.Alerts {
+			if reflect.DeepEqual(k, l) {
+				include = true
+				break
+			}
+		}
+		if include {
+			continue
+		} else {
+			return fmt.Sprintf(".Alerts[%v] not included, got: %v", index, j.Alerts)
+		}
+	}
+	return ""
+}

--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/alertmanager/template"
+)
+
+func TestIncludeWhenDiffOrder(t *testing.T) {
+	expected := template.Data{
+		Status: "FIRING",
+		Alerts: []template.Alert{
+			{
+				Status: "s1",
+			},
+			{
+				Status: "s2",
+			},
+		},
+	}
+
+	got := template.Data{
+		Status: "FIRING",
+		Alerts: []template.Alert{
+			{
+				Status: "s2",
+			},
+			{
+				Status: "s1",
+			},
+		},
+	}
+
+	diff := Include(expected, got)
+	if diff != "" {
+		t.Fatal("should be include when alerts different order")
+	}
+}
+
+func TestIncludeWhenMissItems(t *testing.T) {
+	expected := template.Data{
+		Status: "FIRING",
+		Alerts: []template.Alert{
+			{
+				Status: "s1",
+			},
+		},
+	}
+
+	got := template.Data{
+		Status: "FIRING",
+		Alerts: []template.Alert{
+			{
+				Status: "s2",
+			},
+			{
+				Status: "s1",
+			},
+		},
+	}
+
+	diff := Include(expected, got)
+	if diff != "" {
+		t.Fatal("should be include when alerts different order")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.2.0
+	github.com/google/go-cmp v0.5.0
 	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/client_golang v1.7.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/main.go
+++ b/main.go
@@ -63,8 +63,8 @@ func webhook(evaluateMessage chan<- string, evaluate *Evaluate) http.HandlerFunc
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		jsonData, _ := json.Marshal(data)
-		log.Printf("received webhook payload: %v\n", string(jsonData))
+
+		log.Println("received webhook payload")
 
 		// if evaluateMessage is "", the heartbeat is successful,
 		// if it is not empty, use evaluateMessage as notify message
@@ -89,6 +89,7 @@ func webhook(evaluateMessage chan<- string, evaluate *Evaluate) http.HandlerFunc
 				}
 			case EvaluateInclude, "":
 				if diff != "" {
+					// todo: cmp package does not support get only the more or less part.
 					if strings.Contains(diff, "- ") {
 						evaluateMessage <- diff
 						fmt.Fprintf(os.Stderr, "error: %s, diff: %s\n", "alert payload not included", diff)

--- a/main.go
+++ b/main.go
@@ -84,18 +84,21 @@ func webhook(evaluateMessage chan<- string, evaluate *Evaluate) http.HandlerFunc
 				if diff != "" {
 					evaluateMessage <- diff
 					fmt.Fprintf(os.Stderr, "error: %s, diff: %s\n", "alert payload not euqal", diff)
+					w.WriteHeader(http.StatusOK)
+					return
 				}
 			case EvaluateInclude, "":
 				if diff != "" {
 					if strings.Contains(diff, "- ") {
 						evaluateMessage <- diff
 						fmt.Fprintf(os.Stderr, "error: %s, diff: %s\n", "alert payload not included", diff)
+						w.WriteHeader(http.StatusOK)
+						return
 					}
 				}
 			}
-		} else {
-			evaluateMessage <- ""
 		}
+		evaluateMessage <- ""
 
 		w.WriteHeader(http.StatusOK)
 	}

--- a/notify_interface.go
+++ b/notify_interface.go
@@ -1,5 +1,5 @@
 package main
 
 type NotifyInterface interface {
-	Notify(msg string) error
+	Notify(summary, detail string) error
 }

--- a/notify_pagerduty.go
+++ b/notify_pagerduty.go
@@ -18,13 +18,14 @@ func NewPagerDutyNotify(authKey string) *PagerDuty {
 }
 
 // Notify send notify message to pagerduty
-func (p *PagerDuty) Notify(msg string) error {
-	log.Printf("sending notify: %s to pagerduty\n", msg)
+func (p *PagerDuty) Notify(summary, detail string) error {
+	log.Printf("sending notify: %s to pagerduty\n", summary)
 	pdPayload := pagerduty.V2Payload{
-		Summary:   msg,
+		Summary:   summary,
 		Source:    "DeadMansSwitch",
 		Severity:  "critical",
 		Timestamp: time.Now().Format(time.RFC3339),
+		Details:   detail,
 	}
 
 	event := pagerduty.V2Event{

--- a/notify_pagerduty.go
+++ b/notify_pagerduty.go
@@ -26,6 +26,9 @@ func (p *PagerDuty) Notify(summary, detail string) error {
 		Severity:  "critical",
 		Timestamp: time.Now().Format(time.RFC3339),
 		Details:   detail,
+		Group:     "DeadMansSwitch",
+		// used for group alerting event
+		Class:     summary,
 	}
 
 	event := pagerduty.V2Event{

--- a/payload.json
+++ b/payload.json
@@ -1,29 +1,91 @@
 {
-  "receiver": "webhook",
-  "status": "firing",
-  "alerts": [
+  "receiver":"dead-mans-switch",
+  "status":"firing",
+  "alerts":[
     {
-      "status": "firing",
-      "labels": {
-        "alertname": "WatchDog",
-        "dc": "eu-west-1"
+      "status":"firing",
+      "labels":{
+        "alertname":"Watchdog",
+        "cluster":"base",
+        "prometheus":"monitoring/k8s",
+        "provider":"eks",
+        "region":"us-west-2",
+        "severity":"none"
       },
-      "annotations": {
-        "description": "some description"
+      "annotations":{
+        "message":"This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
       },
-      "startsAt": "2018-08-03T09:52:26.739266876+02:00",
-      "endsAt": "0001-01-01T00:00:00Z"
+      "startsAt":"2020-06-23T03:45:45.022073385Z",
+      "endsAt":"0001-01-01T00:00:00Z",
+      "generatorURL":"http://prometheus-k8s-1:9090/graph?g0.expr=vector%281%29\u0026g0.tab=1",
+      "fingerprint":"18c9684ae47eaa03"
+    },
+    {
+      "status":"firing",
+      "labels":{
+        "alertname":"Watchdog",
+        "cluster":"seed",
+        "prometheus":"monitoring/k8s",
+        "provider":"eks",
+        "region":"us-west-2",
+        "severity":"none"
+      },
+      "annotations":{
+        "message":"This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
+      },
+      "startsAt":"2020-07-08T17:55:15.022073385Z",
+      "endsAt":"0001-01-01T00:00:00Z",
+      "generatorURL":"http://prometheus-k8s-1:9090/graph?g0.expr=vector%281%29\u0026g0.tab=1",
+      "fingerprint":"7f0afb5ad8e81f7f"
+    },
+    {
+      "status":"firing",
+      "labels":{
+        "alertname":"Watchdog",
+        "cluster":"seed",
+        "prometheus":"monitoring/k8s",
+        "provider":"gke",
+        "region":"us-west1",
+        "severity":"none"
+      },
+      "annotations":{
+        "message":"This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
+      },
+      "startsAt":"2020-07-01T02:37:15.022073385Z",
+      "endsAt":"0001-01-01T00:00:00Z",
+      "generatorURL":"http://prometheus-k8s-0:9090/graph?g0.expr=vector%281%29\u0026g0.tab=1",
+      "fingerprint":"9ca228ced419e823"
+    },
+    {
+      "status":"firing",
+      "labels":{
+        "alertname":"Watchdog",
+        "cluster":"seed",
+        "prometheus":"monitoring/k8s",
+        "provider":"gke",
+        "region":"us-west2",
+        "severity":"none"
+      },
+      "annotations":{
+        "message":"This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
+      },
+      "startsAt":"2020-06-23T03:58:15.022073385Z",
+      "endsAt":"0001-01-01T00:00:00Z",
+      "generatorURL":"http://prometheus-k8s-0:9090/graph?g0.expr=vector%281%29\u0026g0.tab=1",
+      "fingerprint":"047137463e459990"
     }
   ],
-  "groupLabels": {
-    "alertname": "WatchDog"
+  "groupLabels":{
+    "alertname":"Watchdog",
+    "severity":"none"
   },
-  "commonLabels": {
-    "alertname": "WatchDog",
-    "dc": "eu-west-1"
+  "commonLabels":{
+    "alertname":"Watchdog",
+    "prometheus":"monitoring/k8s",
+    "severity":"none"
   },
-  "commonAnnotations": {
-    "description": "some description"
+  "commonAnnotations":{
+    "message":"This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
   },
-  "externalURL": "http://alertmanager:9093"
+  "externalURL":"http://alertmanager.ing.dev.shared.aws.tidbcloud.com"
 }

--- a/payload.json
+++ b/payload.json
@@ -87,5 +87,5 @@
   "commonAnnotations":{
     "message":"This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
   },
-  "externalURL":"http://alertmanager.ing.dev.shared.aws.tidbcloud.com"
+  "externalURL":"http://alertmanager:9093"
 }


### PR DESCRIPTION
Because the alert manager is an aggregated services. so we need verify all prometheus can send Watchdog alert to aggregated alert manager. so i introduce evaluate type `equal` and `include`. `include` means that the desired alerting information will be included in the alert payload. In this way, we can avoid send false alerting when adding prometheus