### PR TITLE
stop send notify to pagerduty when evaluate failed

### DIFF
--- a/dead_mans_switch_test.go
+++ b/dead_mans_switch_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestDeadMansSwitchDoesntTrigger(t *testing.T) {
@@ -50,11 +52,7 @@ func TestEvaluateMessageNotNull(t *testing.T) {
 	evaluateMessage := make(chan string)
 	defer close(evaluateMessage)
 
-	notify := ""
-	notifyDetail := ""
 	d := NewDeadMansSwitch(evaluateMessage, 100*time.Millisecond, func(summary, detail string) error {
-		notify = summary
-		notifyDetail = detail
 		return nil
 	})
 
@@ -63,11 +61,7 @@ func TestEvaluateMessageNotNull(t *testing.T) {
 
 	evaluateMessage <- "alert not as expected"
 
-	if notify != "WatchdogAlertPayloadNotAsExpected" {
-		t.Fatal("summary should equal with WatchdogAlertPayloadNotAsExpected")
-	}
-
-	if notifyDetail != "alert not as expected" {
-		t.Fatal("notify detail should be equal with evaluate message")
+	if testutil.ToFloat64(failedEvaluatePayload) == 0 {
+		t.Fatal("failedEvaluatePayload should be > 0 when evaluate failed")
 	}
 }

--- a/evaluate.go
+++ b/evaluate.go
@@ -16,7 +16,7 @@ func Include(i, j template.Data) (diff string) {
 		return fmt.Sprintf("receiver different, expected: %v, got: %v", i.Status, j.Status)
 	}
 
-	for index, k := range i.Alerts {
+	for _, k := range i.Alerts {
 		include := false
 		for _, l := range j.Alerts {
 			if reflect.DeepEqual(k, l) {
@@ -27,7 +27,7 @@ func Include(i, j template.Data) (diff string) {
 		if include {
 			continue
 		} else {
-			return fmt.Sprintf(".Alerts[%v] not included, got: %v", index, j.Alerts)
+			return fmt.Sprintf("expected included: %+v\ngot: %+v", k, j.Alerts)
 		}
 	}
 	return ""


### PR DESCRIPTION
if just one prometheus not send WatchDog ALERT, dead mans switch will send critical alert to pagerduty. i add a metrics to records it. we can add a prometheusrules for the new metrics